### PR TITLE
Setup prometheus and geolocation extensions

### DIFF
--- a/ansible/playbooks/cognit.yaml
+++ b/ansible/playbooks/cognit.yaml
@@ -5,3 +5,7 @@
   hosts: "{{ engine_group | d('engine') }}"
   roles:
     - engine
+- name: Setup opennebula-extensions
+  hosts: "{{ frontend_group | d('frontend') }}"
+  roles:
+    - opennebula-extensions

--- a/ansible/playbooks/roles/engine/tasks/main.yml
+++ b/ansible/playbooks/roles/engine/tasks/main.yml
@@ -23,7 +23,7 @@
     cmd: "./install.sh"
     chdir: "{{ engine_repo }}"
 
-- name: Set the frontend to listen on every host
+- name: Set the engine to listen on every host
   lineinfile:
     path: /etc/provision-engine/engine.conf
     regexp: '^:host:'

--- a/ansible/playbooks/roles/opennebula-extensions/tasks/main.yml
+++ b/ansible/playbooks/roles/opennebula-extensions/tasks/main.yml
@@ -1,44 +1,44 @@
 ---
-- name: Clone Provigion Engine repo
+# TODO: Check oned is ee otherwise Prometheus could not exist
+- name: Clone opennebula-extensions GitHub repository
   ansible.builtin.git:
-    repo: https://github.com/SovereignEdgeEU-COGNIT/provisioning-engine.git
-    dest: "{{ engine_repo }}"
-    force: true
+    repo: https://github.com/SovereignEdgeEU-COGNIT/opennebula-extensions.git
+    dest: "{{ extensions_repo }}"
+  delegate_to: localhost
+  run_once: true
 
-- name: Install Ruby
-  become: true
-  block:
-    - name: Install required packages
-      ansible.builtin.apt:
-        name:
-          - ruby
-          - ruby-dev
-          - build-essential
-          - zlib1g-dev
-        state: present
-        update_cache: true
+- name: Prometheus - Patch 1
+  ansible.builtin.copy:
+    src: "{{ extensions_repo }}/prometheus/patch_datasources.rb"
+    dest: /usr/share/one/patch_datasources.rb
+    owner: root
+    group: root
+    mode: '0644'
 
-- name: Install engine
-  ansible.builtin.command:
-    cmd: "./install.sh"
-    chdir: "{{ engine_repo }}"
+- name: Prometheus - Patch 2
+  ansible.builtin.copy:
+    src: "{{ extensions_repo }}/prometheus/vm_collector.rb"
+    dest: /usr/lib/one/opennebula_exporter/opennebula_vm_collector.rb
+    owner: root
+    group: root
+    mode: '0644'
 
-- name: Set the frontend to listen on every host
-  lineinfile:
-    path: /etc/provision-engine/engine.conf
-    regexp: '^:host:'
-    line: ':host: 0.0.0.0'
+- name: Prometheus - VM Hook
+  ansible.builtin.command: "onehook create {{ extensions_repo }}/prometheus/vm.hook"
+  register: hook_result
+  failed_when: hook_result.rc != 0
+  changed_when: hook_result.rc == 0
 
-- name: Point Engine to frontend
-  ansible.builtin.command:
-    cmd: "./prepare.rb {{ oned }} {{ oneflow }}"
-    chdir: "{{ engine_repo }}/tests"
+- name: Geolocation - Logic
+  ansible.builtin.copy:
+    src: "{{ extensions_repo }}/geolocation/geo.rb"
+    dest: /usr/share/one/geo.rb
+    owner: root
+    group: root
+    mode: '0644'
 
-- name: Start engine
-  ansible.builtin.command: provision-engine-server start
-  ignore_errors: true
-
-- name: Check if engine port is being used
-  ansible.builtin.wait_for:
-    port: 1337
-    timeout: 5
+- name: Geolocation - VM Hook
+  ansible.builtin.command: "onehook create {{ extensions_repo }}/geolocation/geo.hook"
+  register: hook_result
+  failed_when: hook_result.rc != 0
+  changed_when: hook_result.rc == 0

--- a/ansible/playbooks/roles/opennebula-extensions/vars/main.yml
+++ b/ansible/playbooks/roles/opennebula-extensions/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-engine_repo: /home/ubuntu/provision-engine
+extensions_repo: /var/tmp/opennebula-extensions

--- a/opsforge
+++ b/opsforge
@@ -4,6 +4,7 @@ require 'yaml'
 require 'open3'
 require 'json'
 require 'net/http'
+require 'fileutils'
 
 HELP = <<~EOT
     opsforge CLI options
@@ -207,6 +208,8 @@ def clean
         File.delete("#{__dir__}/ansible/#{file}")
     end
 
+    FileUtils.rm_rf('/var/tmp/opennebula-extensions')
+
     File.delete("#{__dir__}/opsforge.log")
 
     puts 'COGNIT deployment succesfully destroyed'
@@ -290,10 +293,13 @@ when 'deploy'
 
     report = <<~EOT
 
+        Infrastructure
         #{JSON.pretty_generate(infra)}
 
-        Logs available at ./opsforge.log'
-        Take a look at AWS cluster provisioning in order to setup your KVM cluster\nhttps://docs.opennebula.io/6.8/provision_clusters/providers/aws_provider.html#aws-provider
+        [INFO] Connect to these hosts with the <ubuntu> user using the provided ssh key'
+        [INFO] Logs available at ./opsforge.log'
+        [POSTINSTALL] Take a look at AWS cluster provisioning in order to setup your KVM cluster\nhttps://docs.opennebula.org/stable/provision_clusters/providers/aws_provider.html#aws-provider
+        [POSTINSTALL] After that, take a look at the Energy Consumption extension\nhttps://github.com/SovereignEdgeEU-COGNIT/opennebula-extensions?tab=readme-ov-file#scaphandre-extension
     EOT
 
     puts report


### PR DESCRIPTION
New ansible role to handle the setup of the prometheus and geolocation opennebula extensions. The scaphandre extension requires the hypervisor hosts to be previously deployed, therefore is not contemplated as of now.

Closes #11 