### PR TITLE
Add flavour variant to sr build process

### DIFF
--- a/ansible/playbooks/roles/kiwi/tasks/main.yml
+++ b/ansible/playbooks/roles/kiwi/tasks/main.yml
@@ -19,15 +19,15 @@
 
 - name: Copy kiwi image description files
   ansible.builtin.copy:
-    src: serverless_runtime
+    src: "{{ flavour }}"
     dest: "{{ kiwi_dest }}/"
     mode: preserve
 
 - name: Use designated serverless runtime version
   ansible.builtin.lineinfile:
-    path: "{{ kiwi_dest }}/serverless_runtime/config.sh"
+    path: "{{ kiwi_dest }}/{{ flavour }}/config.sh"
     regexp: '^SR_VERSION=main'
-    line: "SR_VERSION={{sr_version}}"
+    line: "SR_VERSION={{ sr_version }}"
   when: sr_version is defined
 
 - name: Check if output directory exists and is not empty
@@ -51,7 +51,7 @@
 
 - name: Build kiwi image
   ansible.builtin.command:
-    cmd: kiwi-ng --debug system build --description {{ kiwi_dest }}/serverless_runtime --set-repo obs://openSUSE:Leap:{{ suse_ver }}/standard --target-dir {{ kiwi_dest }}/output
+    cmd: kiwi-ng --debug system build --description {{ kiwi_dest }}/{{ flavour }} --set-repo obs://openSUSE:Leap:{{ suse_ver }}/standard --target-dir {{ kiwi_dest }}/output
   register: kiwi_build
   changed_when: kiwi_build.rc == 0
 

--- a/opsforge
+++ b/opsforge
@@ -20,7 +20,7 @@ HELP = <<~EOT
     opsforge CLI options
         deploy          -> Deploys the COGNIT architecture on AWS
         clean           -> Frees up the resources on the public cloud
-        build_sr [host] -> Trigger the Serverless Runtime Appliance automated build on [host]
+        build_sr [host] [sr_version] [jumphost] [flavour] -> Trigger the Serverless Runtime Appliance automated build on [host]
         help            -> This help message
 EOT
 
@@ -344,7 +344,7 @@ end
 # @param [String] sr_version Serverless Runtime version to install in the App
 # @param [String] jumphost IP/Hostname of the host used as SSH proxy
 #
-def kiwi(host, sr_version = nil, jumphost = nil)
+def kiwi(host, sr_version = nil, jumphost = nil, flavour = 'serverless_runtime')
     inventory = {
         'kiwi' => {
             'hosts' => {
@@ -356,13 +356,17 @@ def kiwi(host, sr_version = nil, jumphost = nil)
         }
     }
 
-    if jumphost
+    if jumphost && !jumphost.empty?
         inventory['kiwi']['hosts']['kiwi1']['ansible_ssh_common_args'] =
             "-o ProxyJump=root@#{jumphost}"
     end
 
-    if sr_version
+    if sr_version && !jumphost.empty?
         inventory['kiwi']['hosts']['kiwi1']['sr_version'] = sr_version
+    end
+
+    if flavour && !flavour.empty?
+        inventory['kiwi']['hosts']['kiwi1']['flavour'] = flavour
     end
 
     Dir.chdir("#{__dir__}/ansible")


### PR DESCRIPTION
The SR App build process now accepts the serverless runtime variant. Each variant is assumed to exist at `ansible/playbooks/roles/kiwi/files/<flavour>/` as a kiwi recipe. The default flavour is `serverless_runtime`. 

To build, for example, `vanilla` flavour

```
 !  ~/P/C/cognit-ops-forge   *$…  ./opsforge build_sr 172.20.0.6 release-cognit-1.0 laptop-devel vanilla                                                               1m41s

PLAY [Setup kiwi builder] ******************************************************

TASK [Gathering Facts] *********************************************************
[WARNING]: Platform linux on host kiwi1 is using the discovered Python
interpreter at /usr/bin/python3.6, but future installation of another Python
interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.16/reference_appendices/interpreter_discovery.html for more information.
ok: [kiwi1]

TASK [kiwi : Verify openSUSE distribution] *************************************
skipping: [kiwi1]

TASK [kiwi : Install required packages] ****************************************
ok: [kiwi1]

TASK [kiwi : Copy kiwi image description files] ********************************
ok: [kiwi1]

TASK [kiwi : Use designated serverless runtime version] ************************
changed: [kiwi1]
```
