### PR TITLE
Add ssl termination to Edge Cluster frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ inventory_kiwi_dev.yaml
 ansible/ansible.cfg
 ansible/inventory.yaml
 ansible/inventory_kiwi.yaml
+ansible/inventory_ecf.yaml
 
 # Ignore generated log
 opsforge.log

--- a/ansible/inventory_ecf_example.yaml
+++ b/ansible/inventory_ecf_example.yaml
@@ -1,0 +1,15 @@
+---
+all:
+  vars:
+    oned: https://cognit-lab.sovereignedge.eu/RPC2
+    oneflow: https://cognit-lab-oneflow.sovereignedge.eu/
+    one_pass: cognit
+edge_cluster_frontend:
+  hosts:
+    edge_cluster_frontend1:
+      ansible_host: ec2-18-117-252-146.us-east-2.compute.amazonaws.com
+      ansible_user: ubuntu
+      cluster_id: 0
+      domain_name: ec2-18-117-252-146.us-east-2.compute.amazonaws.com
+      cognit_frontend: https://cognit-lab-frontend.sovereignedge.eu/
+      one_user: cognit_admin

--- a/ansible/playbooks/edge_cluster.yaml
+++ b/ansible/playbooks/edge_cluster.yaml
@@ -1,0 +1,4 @@
+- name: Setup Edge Cluster Frontend
+  hosts: "{{ edge_cluster_frontend_group | d('edge_cluster_frontend') }}"
+  roles:
+    - edge_cluster_frontend

--- a/ansible/playbooks/roles/cognit_edge_cluster_frontend/vars/main.yml
+++ b/ansible/playbooks/roles/cognit_edge_cluster_frontend/vars/main.yml
@@ -1,5 +1,0 @@
----
-repo_url: https://github.com/SovereignEdgeEU-COGNIT/edgecluster-frontend.git
-repo_dest: /home/ubuntu/edgecluster-frontend
-api_port: 1339
-conf_file: cognit-edge_cluster_frontend.conf

--- a/ansible/playbooks/roles/cognit_frontend/defaults/main.yml
+++ b/ansible/playbooks/roles/cognit_frontend/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+default_cluster: 0

--- a/ansible/playbooks/roles/cognit_frontend/tasks/api.yml
+++ b/ansible/playbooks/roles/cognit_frontend/tasks/api.yml
@@ -1,0 +1,49 @@
+---
+- name: Clone Cognit Frontend repo
+  ansible.builtin.git:
+    repo: "{{ repo_url }}"
+    dest: "{{ repo_dest }}"
+    version: "{{ version | default('main') }}"
+
+- name: Install python3-pip
+  ansible.builtin.package:
+    name: python3-pip
+    state: present
+
+- name: Install pip dependencies
+  ansible.builtin.pip:
+    requirements: "{{ repo_dest }}/requirements.txt"
+    state: present
+
+- name: Configure COGNIT Frontend
+  ansible.builtin.template:
+    src: "{{ conf_file }}.j2"
+    dest: "/etc/{{ conf_file }}"
+    mode: "0644"
+
+- name: Get PID of process running on uvicorn port
+  ansible.builtin.command: lsof -ti:{{ api_port }}
+  register: pid
+  ignore_errors: true
+  changed_when: pid.rc == 0
+  failed_when: pid.rc != 0
+
+- name: Kill the process if it exists
+  ansible.builtin.command: kill -9 {{ pid.stdout }}
+  ignore_errors: true
+  register: kill
+  changed_when: kill.rc == 0
+  failed_when: kill.rc != 0
+  when: pid
+
+- name: Start uvicorn
+  ansible.builtin.shell: |
+    nohup python3 {{ repo_dest }}/src/main.py > {{ log_file }} 2>&1 &
+  register: uvicorn
+  changed_when: uvicorn.rc == 0
+  failed_when: uvicorn.rc != 0
+
+- name: Wait for uvicorn to start
+  ansible.builtin.wait_for:
+    port: "{{ api_port }}"
+    timeout: 10

--- a/ansible/playbooks/roles/cognit_frontend/templates/cognit-frontend.conf.j2
+++ b/ansible/playbooks/roles/cognit_frontend/templates/cognit-frontend.conf.j2
@@ -3,5 +3,5 @@ host: 0.0.0.0
 port: {{ api_port }}
 one_xmlrpc: {{ oned }}
 ai_orchestrator_endpoint: {{ ai_instance_ip }}
-default_cluster: 0
-log_level: info
+default_cluster: {{ default_cluster }}
+log_level: {{ log_level }}

--- a/ansible/playbooks/roles/cognit_frontend/vars/main.yml
+++ b/ansible/playbooks/roles/cognit_frontend/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 repo_url: https://github.com/SovereignEdgeEU-COGNIT/cognit-frontend.git
-repo_dest: /home/ubuntu/cognit-frontend
+repo_dest: /opt/cognit-frontend
 api_port: 1338
 conf_file: cognit-frontend.conf
+log_level: info
+log_file: /var/log/cognit_frontend.log

--- a/ansible/playbooks/roles/edge_cluster_frontend/defaults/main.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/defaults/main.yml
@@ -1,0 +1,2 @@
+cluster_id: 0
+web_port: 443

--- a/ansible/playbooks/roles/edge_cluster_frontend/handlers/main.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: restarted

--- a/ansible/playbooks/roles/edge_cluster_frontend/tasks/api.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/tasks/api.yml
@@ -9,7 +9,6 @@
   ansible.builtin.package:
     name: python3-pip
     state: present
-    update-cache: true
 
 - name: Install pip dependencies
   ansible.builtin.pip:
@@ -21,6 +20,19 @@
     src: "{{ conf_file }}.j2"
     dest: "/etc/{{ conf_file }}"
     mode: "0644"
+
+- name: Create Edge Cluster auth dir
+  ansible.builtin.file:
+    path: "{{ auth_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Configure Edge Cluster Frontend auth
+  ansible.builtin.template:
+    src: "{{ auth_file }}.j2"
+    dest: "{{ auth_dir }}/{{ auth_file }}"
+    mode: "0600"
+
 
 - name: Get PID of process running on uvicorn port
   ansible.builtin.command: lsof -ti:{{ api_port }}
@@ -39,7 +51,7 @@
 
 - name: Start uvicorn
   ansible.builtin.shell: |
-    nohup python3 {{ repo_dest }}/src/main.py > /var/log/uvicorn.log 2>&1 &
+    nohup python3 {{ repo_dest }}/src/main.py > {{ log_file }} 2>&1 &
   register: uvicorn
   changed_when: uvicorn.rc == 0
   failed_when: uvicorn.rc != 0
@@ -47,4 +59,4 @@
 - name: Wait for uvicorn to start
   ansible.builtin.wait_for:
     port: "{{ api_port }}"
-    timeout: 5
+    timeout: 10

--- a/ansible/playbooks/roles/edge_cluster_frontend/tasks/main.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/tasks/main.yml
@@ -3,5 +3,8 @@
   ansible.builtin.package:
     update-cache: true
 
-- name: Set up COGNIT Frontend API
+- name: Set up Edge Cluster Frontend API
   ansible.builtin.include_tasks: api.yml
+
+- name: Set up SSL for Edge Cluster Frontend API
+  ansible.builtin.include_tasks: ssl.yml

--- a/ansible/playbooks/roles/edge_cluster_frontend/tasks/ssl.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/tasks/ssl.yml
@@ -1,0 +1,65 @@
+- name: Install Nginx
+  ansible.builtin.apt:
+    name: nginx
+    state: present
+
+- name: Create SSL certificate directory
+  ansible.builtin.file:
+    path: "{{ nginx_ssl_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Copy provided SSL certificate
+  ansible.builtin.copy:
+    src: "{{ ssl_certificate_path }}"
+    dest: "{{ cert_crt }}"
+    mode: '0644'
+  when: ssl_certificate_path is defined
+
+- name: Copy provided SSL certificate key
+  ansible.builtin.copy:
+    src: "{{ ssl_certificate_key_path }}"
+    dest: "{{ cert_key }}"
+    mode: '0600'
+  when: ssl_certificate_key_path is defined
+
+- name: Install OpenSSL
+  ansible.builtin.apt:
+    name: openssl
+    state: present
+  when: not ssl_certificate_path is defined
+
+- name: Generate self-signed SSL certificate
+  ansible.builtin.command: >
+    openssl req -new -nodes -x509
+    -subj "/C=ES/ST=Madrid/L=Madrid/O=OpenNebulaSystemsSL/CN={{ domain_name }}"
+    -days 365
+    -keyout "{{ cert_key }}"
+    -out "{{ cert_crt }}"
+  args:
+    creates: "{{ cert_crt }}"
+  when: not ssl_certificate_key_path is defined
+
+- name: Configure Nginx reverse proxy
+  ansible.builtin.template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+    mode: '0644'
+  notify:
+    - Restart Nginx
+
+- name: Ensure Nginx is running and enabled
+  ansible.builtin.systemd:
+    name: nginx
+    state: started
+    enabled: true
+
+- name: Fetch generated SSL certificate files
+  ansible.builtin.fetch:
+    src: "{{ item }}"
+    dest: "{{ lookup('env', 'HOME') }}/.cognit_ssl_certs/"
+    flat: true
+  loop:
+    - "{{ cert_crt }}"
+    - "{{ cert_key }}"
+  when: not ssl_certificate_key_path is defined

--- a/ansible/playbooks/roles/edge_cluster_frontend/templates/cognit-edge_cluster_frontend.conf.j2
+++ b/ansible/playbooks/roles/edge_cluster_frontend/templates/cognit-edge_cluster_frontend.conf.j2
@@ -4,5 +4,5 @@ port: {{ api_port }}
 one_xmlrpc: {{ oned }}
 oneflow: {{ oneflow }}
 cognit_frontend: {{ cognit_frontend }}
-default_cluster: 0
-log_level: info
+cluster_id: {{ cluster_id }}
+log_level: {{ log_level }}

--- a/ansible/playbooks/roles/edge_cluster_frontend/templates/nginx.conf.j2
+++ b/ansible/playbooks/roles/edge_cluster_frontend/templates/nginx.conf.j2
@@ -1,0 +1,35 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    ssl_certificate {{ cert_crt }};
+    ssl_certificate_key {{ cert_key }};
+
+    server {
+        listen {{ web_port}};
+        listen [::]:{{ web_port}};
+        server_name {{ domain_name }};
+
+        # Redirect all HTTP requests to HTTPS
+        return 301 https://$server_name:{{ web_port }}$request_uri;
+    }
+
+    server {
+        listen {{ web_port }} ssl;
+        server_name {{ domain_name }};
+
+        # Look for Edge Cluster Frontend API
+        location / {
+            proxy_pass http://localhost:{{ api_port }}/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Origin $http_origin;
+            proxy_set_header X-Forwarded-Host $host;
+        }
+
+    }
+}

--- a/ansible/playbooks/roles/edge_cluster_frontend/templates/one_auth.j2
+++ b/ansible/playbooks/roles/edge_cluster_frontend/templates/one_auth.j2
@@ -1,0 +1,1 @@
+{{ one_user }}:{{ one_pass }}

--- a/ansible/playbooks/roles/edge_cluster_frontend/vars/main.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/vars/main.yml
@@ -1,0 +1,14 @@
+---
+repo_url: https://github.com/SovereignEdgeEU-COGNIT/edgecluster-frontend.git
+repo_dest: /opt/edgecluster-frontend
+
+conf_file: cognit-edge_cluster_frontend.conf
+auth_dir: /root/.one
+auth_file: one_auth
+api_port: 1339
+log_level: info
+log_file: /var/log/cognit_edge_cluster_frontend.log
+
+nginx_ssl_dir: /etc/nginx/ssl
+cert_crt: "{{ nginx_ssl_dir }}/certificate.crt"
+cert_key: "{{ nginx_ssl_dir }}/certificate.key"

--- a/ansible/playbooks/roles/engine/vars/main.yml
+++ b/ansible/playbooks/roles/engine/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 repo_url: https://github.com/SovereignEdgeEU-COGNIT/provisioning-engine.git
-repo_dest: /home/ubuntu/provision-engine
+repo_dest: /opt/provision-engine
 ruby_dependencies:
   - ruby
   - ruby-dev

--- a/ansible/playbooks/roles/opennebula-extensions/vars/main.yml
+++ b/ansible/playbooks/roles/opennebula-extensions/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 repo_url: https://github.com/SovereignEdgeEU-COGNIT/opennebula-extensions.git
-repo_dest: /var/tmp/opennebula-extensions
+repo_dest: /opt/opennebula-extensions


### PR DESCRIPTION
- Added SSL termination for edge cluster frontend. Example run

```
 ~/P/C/cognit-ops-forge   ecf_ssl *$…  ansible  ansible-playbook playbooks/edge_cluster.yaml -i inventory_ecf.yaml                                                       38s

PLAY [Setup Edge Cluster Frontend] ***********************************************************************************************************************************************

TASK [edge_cluster_frontend : Refresh package manager cache] *********************************************************************************************************************
[WARNING]: Platform linux on host edge_cluster_frontend1 is using the discovered Python interpreter at /usr/bin/python3.10, but future installation of another Python interpreter
could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.17/reference_appendices/interpreter_discovery.html for more information.
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Set up Edge Cluster Frontend API] ******************************************************************************************************************
included: /Users/dann1/Projects/Cognit/cognit-ops-forge/ansible/playbooks/roles/edge_cluster_frontend/tasks/api.yml for edge_cluster_frontend1

TASK [edge_cluster_frontend : Clone Cognit Frontend repo] ************************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Install python3-pip] *******************************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Install pip dependencies] **************************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Configure Edge Cluster Frontend] *******************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Create Edge Cluster auth dir] **********************************************************************************************************************
ok: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Configure Edge Cluster Frontend auth] **************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Get PID of process running on uvicorn port] ********************************************************************************************************
fatal: [edge_cluster_frontend1]: FAILED! => changed=false
  cmd:
  - lsof
  - -ti:1339
  delta: '0:00:00.070405'
  end: '2024-11-07 02:21:27.331642'
  failed_when_result: true
  msg: non-zero return code
  rc: 1
  start: '2024-11-07 02:21:27.261237'
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
...ignoring

TASK [edge_cluster_frontend : Kill the process if it exists] *********************************************************************************************************************
fatal: [edge_cluster_frontend1]: FAILED! => changed=false
  cmd:
  - kill
  - '-9'
  delta: '0:00:00.010358'
  end: '2024-11-07 02:21:28.299557'
  failed_when_result: true
  msg: non-zero return code
  rc: 1
  start: '2024-11-07 02:21:28.289199'
  stderr: |2-

    Usage:
     kill [options] <pid> [...]

    Options:
     <pid> [...]            send signal to every <pid> listed
     -<signal>, -s, --signal <signal>
                            specify the <signal> to be sent
     -q, --queue <value>    integer value to be sent with the signal
     -l, --list=[<signal>]  list all signal names, or convert one to a name
     -L, --table            list all signal names in a nice table

     -h, --help     display this help and exit
     -V, --version  output version information and exit

    For more details see kill(1).
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
...ignoring

TASK [edge_cluster_frontend : Start uvicorn] *************************************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Wait for uvicorn to start] *************************************************************************************************************************
ok: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Set up SSL for Edge Cluster Frontend API] **********************************************************************************************************
included: /Users/dann1/Projects/Cognit/cognit-ops-forge/ansible/playbooks/roles/edge_cluster_frontend/tasks/ssl.yml for edge_cluster_frontend1

TASK [edge_cluster_frontend : Install Nginx] *************************************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Create SSL certificate directory] ******************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Copy provided SSL certificate] *********************************************************************************************************************
skipping: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Copy provided SSL certificate key] *****************************************************************************************************************
skipping: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Install OpenSSL] ***********************************************************************************************************************************
ok: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Generate self-signed SSL certificate] **************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Configure Nginx reverse proxy] *********************************************************************************************************************
changed: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Ensure Nginx is running and enabled] ***************************************************************************************************************
ok: [edge_cluster_frontend1]

TASK [edge_cluster_frontend : Fetch generated SSL certificate files] *************************************************************************************************************
changed: [edge_cluster_frontend1] => (item=/etc/nginx/ssl/certificate.crt)
changed: [edge_cluster_frontend1] => (item=/etc/nginx/ssl/certificate.key)

RUNNING HANDLER [edge_cluster_frontend : Restart Nginx] **************************************************************************************************************************
changed: [edge_cluster_frontend1]

PLAY RECAP ***********************************************************************************************************************************************************************
edge_cluster_frontend1     : ok=21   changed=13   unreachable=0    failed=0    skipped=2    rescued=0    ignored=2
```
- Some other ansible improvements
