### PR TITLE
Allow configuring nginx timeout for long running sync functions

### DIFF
--- a/ansible/playbooks/roles/edge_cluster_frontend/templates/nginx.conf.j2
+++ b/ansible/playbooks/roles/edge_cluster_frontend/templates/nginx.conf.j2
@@ -6,6 +6,9 @@ http {
     ssl_certificate {{ cert_crt }};
     ssl_certificate_key {{ cert_key }};
 
+    # increase if needed for long running sync functions
+    proxy_read_timeout {{ proxy_read_timeout }};
+
     server {
         listen {{ web_port}};
         listen [::]:{{ web_port}};

--- a/ansible/playbooks/roles/edge_cluster_frontend/vars/main.yml
+++ b/ansible/playbooks/roles/edge_cluster_frontend/vars/main.yml
@@ -12,3 +12,4 @@ log_file: /var/log/cognit_edge_cluster_frontend.log
 nginx_ssl_dir: /etc/nginx/ssl
 cert_crt: "{{ nginx_ssl_dir }}/certificate.crt"
 cert_key: "{{ nginx_ssl_dir }}/certificate.key"
+proxy_read_timeout: 600


### PR DESCRIPTION
Use cases have reported long running sync functions returned 504 after a minute even though both the SR and the ECFE didn't log the error. Only nginx did. This solves the problem, confirmed by the use case user.